### PR TITLE
Improved cross-platform path handling

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,5 @@
 const gulp = require('gulp');
+const path = require('path');
 var fs = require('fs')
 const del = require('del');
 const ts = require('gulp-typescript');
@@ -57,7 +58,7 @@ function buildManifest(output = null) {
 	return (cb) => gulp.src(PACKAGE.main) // collect the source files
 		.pipe(rename({ extname: '.js' })) // rename their extensions to `.js`
 		.pipe(gulp.src(CSS + GLOB)) // grab all the CSS files
-		.on('data', file => files.push(file.path.replace(file.base, file.base.replace(file.cwd + '/', '')))) // Collect all the file paths
+		.on('data', file => files.push(path.relative(file.cwd, file.path))) // Collect all the file paths
 		.on('end', () => { // output the filepaths to the module.json
 			if (files.length == 0)
 				throw Error('No files found in ' + SOURCE + GLOB + " or " + CSS + GLOB);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ const CSS = 'css/';
 
 var PACKAGE = JSON.parse(fs.readFileSync('package.json'));
 function reloadPackage(cb) { PACKAGE = JSON.parse(fs.readFileSync('package.json')); cb(); }
-function DEV_DIST() { return PACKAGE.devDir + PACKAGE.name + '/'; }
+function DEV_DIST() { return path.join(PACKAGE.devDir, PACKAGE.name) + '/'; }
 
 String.prototype.replaceAll = function (pattern, replace) { return this.split(pattern).join(replace); }
 function pdel(patterns, options) { return () => { return del(patterns, options); }; }


### PR DESCRIPTION
* Generate module.json with relative paths on both unix and windows systems
* Allow `devDir` to work regardless of trailing slash
   * Previously, if the `devDir` path was set to `/path/to/Foundry/data/modules` and `name` was set to `my-module-name` the module would be copied to `/path/to/Foundry/data/modulesmy-module-name` instead of correctly joining the paths.

I tested these changes on both Windows and WSL. A test on a real life unix system would probably be best though.

Fixes #3 